### PR TITLE
AndroidPageObjectTest improvement.

### DIFF
--- a/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocatorFactory.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumElementLocatorFactory.java
@@ -8,10 +8,7 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 
 class AppiumElementLocatorFactory implements ElementLocatorFactory, ResetsImplicitlyWaitTimeOut {
-    private static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
-    private static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
-	
-	private final SearchContext searchContext;
+    private final SearchContext searchContext;
 	private final TimeOutContainer timeOutContainer;
 
 	public AppiumElementLocatorFactory(SearchContext searchContext,
@@ -21,7 +18,8 @@ class AppiumElementLocatorFactory implements ElementLocatorFactory, ResetsImplic
 	}
 	
 	public AppiumElementLocatorFactory(SearchContext searchContext) {
-		this(searchContext, DEFAULT_IMPLICITLY_WAIT_TIMEOUT, DEFAULT_TIMEUNIT);
+		this(searchContext, AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT, 
+				AppiumFieldDecorator.DEFAULT_TIMEUNIT);
 	}	
 
 	public ElementLocator createLocator(Field field) {

--- a/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
+++ b/src/main/java/io/appium/java_client/pagefactory/AppiumFieldDecorator.java
@@ -47,6 +47,10 @@ public class AppiumFieldDecorator implements FieldDecorator, ResetsImplicitlyWai
 	
 	private final AppiumElementLocatorFactory factory;
 
+	public static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
+
+	public static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
+
 	public AppiumFieldDecorator(SearchContext context, long implicitlyWaitTimeOut, TimeUnit timeUnit) {
 		factory = new AppiumElementLocatorFactory(context, implicitlyWaitTimeOut, timeUnit);
 	}

--- a/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/AndroidPageObjectTest.java
@@ -13,6 +13,7 @@ import io.appium.java_client.remote.MobileCapabilityType;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -140,7 +141,8 @@ public class AndroidPageObjectTest {
 	    capabilities.setCapability(MobileCapabilityType.APP, app.getAbsolutePath());
 	    driver = new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
 
-		PageFactory.initElements(new AppiumFieldDecorator(driver), this);
+	    //This time out is set because test can be run on slow Android SDK emulator
+		PageFactory.initElements(new AppiumFieldDecorator(driver, 5, TimeUnit.SECONDS), this);
 	}
 
 	@After

--- a/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
+++ b/src/test/java/io/appium/java_client/pagefactory_tests/TimeOutResetTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.support.FindAll;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
@@ -20,14 +21,9 @@ public class TimeOutResetTest {
 	private WebDriver driver;
 	private final static long ACCEPTABLE_DELTA_MILLS = 500;
 
-	/**
-	 * Default time out parameters
-	 */
 
-	private static long DEFAULT_IMPLICITLY_WAIT_TIMEOUT = 1;
-	private static TimeUnit DEFAULT_TIMEUNIT = TimeUnit.SECONDS;
-
-	@FindBy(className = "ClassWhichDoesNotExist")
+	@FindAll({@FindBy(className = "ClassWhichDoesNotExist"),
+	@FindBy(className = "OneAnotherClassWhichDoesNotExist")})
 	private List<WebElement> stubElements;
 	private AppiumFieldDecorator afd;
 
@@ -69,10 +65,10 @@ public class TimeOutResetTest {
 
 	@Test
 	public void test() {
-		checkTimeDifference(DEFAULT_IMPLICITLY_WAIT_TIMEOUT, DEFAULT_TIMEUNIT,
+		checkTimeDifference(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT, AppiumFieldDecorator.DEFAULT_TIMEUNIT,
 				getBenchMark());
-		System.out.println(String.valueOf(DEFAULT_IMPLICITLY_WAIT_TIMEOUT)
-				+ " " + DEFAULT_TIMEUNIT.toString() + ": Fine");
+		System.out.println(String.valueOf(AppiumFieldDecorator.DEFAULT_IMPLICITLY_WAIT_TIMEOUT)
+				+ " " + AppiumFieldDecorator.DEFAULT_TIMEUNIT.toString() + ": Fine");
 
 		afd.resetImplicitlyWaitTimeOut(15500000, TimeUnit.MICROSECONDS);
 		checkTimeDifference(15500000, TimeUnit.MICROSECONDS, getBenchMark());


### PR DESCRIPTION
Here is an answer to the question asked [here](https://github.com/appium/java-client/pull/116)

I could reproduce the problem. I made up the slowest Android SDK  emulator as I could.
![tests3](https://cloud.githubusercontent.com/assets/4927589/4431287/25295872-4660-11e4-8984-b899e2786302.png)

This problem was reproduced randomly after some machine reboots. Next test running were always successful. It is strange.

Here are stack traces of exceptions which I could catch:

``` java
org.openqa.selenium.NoSuchElementException: Cann't locate an element by this strategy: By.chained({By.AndroidUIAutomator: new UiSelector().resourceId("android:id/list"),By.className: android.widget.TextView})
For documentation on this error, please visit: http://seleniumhq.org/exceptions/no_such_element.html
Build info: version: '2.43.1', revision: '5163bceef1bc36d43f3dc0b83c88998168a363a0', time: '2014-09-10 09:43:55'
System info: host: '***', ip: '***', os.name: 'Windows 7', os.arch: 'amd64', os.version: '6.1', java.version: '1.7.0_45'
Driver info: driver.version: unknown
    at io.appium.java_client.pagefactory.AppiumElementLocator.findElement(AppiumElementLocator.java:132)
    at io.appium.java_client.pagefactory.ElementInterceptor.intercept(ElementInterceptor.java:26)
    at org.openqa.selenium.remote.RemoteWebElement$$EnhancerByCGLIB$$d03393d8.getAttribute(<generated>)
```

**at io.appium.java_client.pagefactory_tests.AndroidPageObjectTest.androidChainSearchElementTest(AndroidPageObjectTest.java:246)**

``` java
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
```

``` java
java.lang.AssertionError: Values should be different. Actual: 0
    at org.junit.Assert.fail(Assert.java:88)
    at org.junit.Assert.failEquals(Assert.java:185)
    at org.junit.Assert.assertNotEquals(Assert.java:161)
    at org.junit.Assert.assertNotEquals(Assert.java:198)
    at org.junit.Assert.assertNotEquals(Assert.java:209)
    at 
```

**io.appium.java_client.pagefactory_tests.AndroidPageObjectTest.areMobileElementsTest(AndroidPageObjectTest.java:211)**

``` java
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)
```

I think that sometimes default time out  (1 second) is not enough.  In order to solve this problem were created before:

``` java
appiumFieldDecoratorInstance.resetImplicitlyWaitTimeOut(desiredTime, desiredTimeUnit);
```

and

``` java
new AppiumFieldDecorator(driver, desiredTime, desiredTimeUnit);
```
